### PR TITLE
refactor: Simplify imports iter

### DIFF
--- a/src/import.rs
+++ b/src/import.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-#[derive(Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Import {
     pub name: Option<String>,
     pub url: String,

--- a/src/sorter.rs
+++ b/src/sorter.rs
@@ -1,81 +1,19 @@
 use super::import::Import;
-use std::collections::HashMap;
-
-#[derive(Eq, Hash, PartialEq, Clone, Debug, PartialOrd, Ord)]
-pub enum ImportType<'a> {
-    Core,
-    ThirdParty,
-    Custom(&'a str),
-}
 
 #[derive(Clone)]
 pub struct ImportSorter<'a> {
-    original: Vec<&'a str>,
-    buckets: HashMap<ImportType<'a>, Vec<Import>>,
-}
-
-enum SorterOrder {
-    Core,
-    ThirdParty,
-    Custom,
-}
-
-/// Iterator object over the import buckets in the sorter.
-/// It releases import buckets one by one in the original order
-/// specified by the user via command line arguments.
-/// First it receives `Core`, then `ThirdParty` buckets, and only
-/// then all the custom buckets specified by the user order.
-pub struct ImportSorterIter<'a> {
-    current_key: SorterOrder,
-    current_custom: usize,
-    sorter: &'a ImportSorter<'a>,
-}
-
-impl<'a> Iterator for ImportSorterIter<'a> {
-    type Item = &'a Vec<Import>;
-    fn next(&mut self) -> Option<Self::Item> {
-        // Lets go through all the possible bucket types
-        let (new_key, bucket) = match self.current_key {
-            // for core and third party buckets just return those, and only then
-            // deal with the order of the custom ones
-            SorterOrder::Core => (SorterOrder::ThirdParty, Some(ImportType::Core)),
-            SorterOrder::ThirdParty => (SorterOrder::Custom, Some(ImportType::ThirdParty)),
-            SorterOrder::Custom => {
-                // if theres no custom buckets, or if custom bucket is gone through,
-                // then just return nothing.
-                // otherwise, get the correct package name and create bucket key from it
-                if self.current_custom == self.sorter.original.len() {
-                    (SorterOrder::Custom, None)
-                } else {
-                    let package = self.sorter.original[self.current_custom];
-                    self.current_custom += 1;
-                    (SorterOrder::Custom, Some(ImportType::Custom(package)))
-                }
-            }
-        };
-
-        // after correct bucket key has been obtained, return this bucket.
-        // in case no bucket key was found, return nothing. it is efficiently
-        // the end of the iterator
-        self.current_key = new_key;
-        bucket.map(|k| &self.sorter.buckets[&k])
-    }
+    core: Vec<Import>,
+    third_party: Vec<Import>,
+    custom: Vec<(&'a str, Vec<Import>)>,
 }
 
 impl<'a> ImportSorter<'a> {
     pub fn new(packages: Vec<&'a str>) -> ImportSorter<'a> {
-        let mut is = ImportSorter {
-            original: packages,
-            buckets: HashMap::new(),
-        };
-
-        is.buckets.insert(ImportType::Core, Vec::new());
-        is.buckets.insert(ImportType::ThirdParty, Vec::new());
-        for p in &is.original {
-            is.buckets.insert(ImportType::Custom(p), Vec::new());
+        ImportSorter {
+            core: vec![],
+            third_party: vec![],
+            custom: packages.into_iter().map(|p| (p, Vec::new())).collect(),
         }
-
-        is
     }
 
     /// Since we need to be able to pick up the best suitable
@@ -85,77 +23,58 @@ impl<'a> ImportSorter<'a> {
     /// suitable.
     /// it should have linear complexity, and since we do not expect
     /// many buckets to exist, should not make things complex at all.
-    fn suitable_custom_bucket_name(&self, name: &str) -> Option<&'a str> {
-        let mut suitable_names = Vec::new();
-        for k in self.buckets.keys() {
-            if let ImportType::Custom(bucket_name) = k {
-                if name.starts_with(bucket_name) {
-                    suitable_names.push(*bucket_name);
-                }
-            }
-        }
-        if suitable_names.is_empty() {
-            return None;
-        }
-        let mut len = 0;
-        let mut index = 0;
-        for (i, n) in suitable_names.iter().enumerate() {
-            if n.len() > len {
-                len = n.len();
-                index = i;
-            }
-        }
-        Some(suitable_names[index])
+    fn suitable_custom_bucket(&mut self, name: &str) -> Option<&mut Vec<Import>> {
+        self.custom
+            .iter_mut()
+            .filter(|(bucket_name, _)| name.starts_with(*bucket_name))
+            .max_by_key(|(bucket_name, _)| bucket_name.len())
+            .map(|(_, bucket)| bucket)
     }
 
-    pub fn iter(&self) -> ImportSorterIter {
-        ImportSorterIter {
-            current_key: SorterOrder::Core,
-            current_custom: 0,
-            sorter: self,
-        }
+    fn custom_buckets_iter(&self) -> impl Iterator<Item = &Vec<Import>> {
+        self.custom.iter().map(|(_, b)| b)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &Vec<Import>> {
+        [&self.core, &self.third_party]
+            .into_iter()
+            .chain(self.custom_buckets_iter())
     }
 
     pub fn insert(&mut self, i: Import) {
         let s = &i.url;
-        if s.contains('.') && s.contains('/') {
+        let bucket = if s.contains('.') && s.contains('/') {
             // try to insert custom import into the custom bucket
-            if let Some(bn) = self.suitable_custom_bucket_name(s) {
-                if let Some(bucket) = self.buckets.get_mut(&ImportType::Custom(bn)) {
-                    bucket.push(i);
-                    return;
-                }
+            if let Some(bucket) = self.suitable_custom_bucket(s) {
+                bucket
+            } else {
+                // could not find custom bucket, let's insert into 3rd party one
+                &mut self.third_party
             }
-
-            // could not find custom bucket, let's insert into 3rd party one
-            self.buckets
-                .get_mut(&ImportType::ThirdParty)
-                .unwrap()
-                .push(i);
-            return;
-        }
-
-        // otherwise, goes into the core import bucket
-        self.buckets.get_mut(&ImportType::Core).unwrap().push(i);
+        } else {
+            // otherwise, goes into the core import bucket
+            &mut self.core
+        };
+        bucket.push(i);
     }
 
     pub fn sort(&mut self) {
-        for v in &mut self.buckets.values_mut() {
+        for v in [&mut self.core, &mut self.third_party]
+            .into_iter()
+            .chain(self.custom.iter_mut().map(|(_, b)| b))
+        {
             v.sort_by(|i1, i2| i1.url.cmp(&i2.url));
         }
     }
 
     pub fn imports_count(&self) -> usize {
-        self.buckets.values().map(Vec::len).sum()
+        self.core.len()
+            + self.third_party.len()
+            + self.custom_buckets_iter().map(Vec::len).sum::<usize>()
     }
 
     pub fn get_single_count(&self) -> Option<&Import> {
-        for v in self.buckets.values() {
-            if v.len() == 1 {
-                return v.get(0);
-            }
-        }
-        None
+        self.iter().find(|v| v.len() == 1).map(|v| &v[0])
     }
 }
 
@@ -169,28 +88,47 @@ mod tests {
         let mut is = ImportSorter::new(ps);
 
         is.insert(Import {
-            name: None,
-            url: "github.com/S1/hrechu".to_string(),
-        });
-
-        is.insert(Import {
             name: Some("hurpcoerc".to_string()),
             url: "github.com/S1/prchu".to_string(),
         });
-
+        is.insert(Import {
+            name: None,
+            url: "github.com/S1/hrechu".to_string(),
+        });
         is.insert(Import {
             name: Some("alices".to_string()),
             url: "github.com/alice/very_project".to_string(),
         });
 
-        assert_eq!(
-            2,
-            is.buckets
-                .get(&ImportType::Custom("github.com/S1"))
-                .unwrap()
-                .len()
-        );
+        is.sort();
 
-        assert_eq!(1, is.buckets.get(&ImportType::ThirdParty).unwrap().len());
+        let s1_imports = is
+            .custom
+            .iter()
+            .find(|(n, _)| *n == "github.com/S1")
+            .map(|(_, b)| b)
+            .unwrap();
+        assert_eq!(
+            s1_imports,
+            &[
+                Import {
+                    name: None,
+                    url: "github.com/S1/hrechu".to_string()
+                },
+                Import {
+                    name: Some("hurpcoerc".to_string()),
+                    url: "github.com/S1/prchu".to_string()
+                },
+            ]
+        );
+        assert_eq!(is.imports_count(), 3);
+        assert_eq!(is.third_party.len(), 1);
+        assert_eq!(
+            is.get_single_count(),
+            Some(&Import {
+                name: Some("alices".to_string()),
+                url: "github.com/alice/very_project".to_string(),
+            })
+        );
     }
 }


### PR DESCRIPTION
### Overview

`ImportSorter` stores 3 types of imports in separate allocations, which removes the need for the `ImportType` enum. Though, some things are slower now (e.g. `get_single_count` as it iterates over 3 vectors) - probably not much slower, but it could make sense to check what usage patterns are the most common ones & adjust the data structure to optimize those patterns.

`HashMap` is replaced with a vector, since only the `suitable_custom_bucket` function needs it and iterates over its keys. `suitable_custom_bucket` returns the proper bucket directly, so there is no need for value access later on inside `insert`, so, using a vector is simpler.

`ImportSorterIter` over different buckets is replaced with:

```rust
[&self.core, &self.third_party]
    .into_iter()
    .chain(self.custom.iter().map(|(_, b)| b))
```

Which is effectively the same though, it might occupy a bit more space on the stack (I didn't check it).

Also added a few more tests.